### PR TITLE
replace shallowCopy for ARC/ORC

### DIFF
--- a/cello.nim
+++ b/cello.nim
@@ -491,7 +491,10 @@ proc rotate*(s: string, i: int): RotatedString =
 
 proc rotate*(s: var string, i: int): RotatedString =
   result = RotatedString(shift: i)
-  shallowCopy(result.underlying, s)
+  when defined(gcArc) or defined(gcOrc):
+    result.underlying = s
+  else:
+    shallowCopy(result.underlying, s)
 
 proc `[]`*(r: RotatedString, i: int): char {.inline.} =
   let L = r.underlying.len

--- a/tests/rotated_string.nim
+++ b/tests/rotated_string.nim
@@ -42,7 +42,8 @@ suite "rotated strings":
       y = x.rotate(5)
 
     y[0] = 'f'
-    check x[5] == 'f'
+    when declared(shallowCopy):
+      check x[5] == 'f'
   test "transforming to string":
     var x = "Hello, world".rotate(7)
 


### PR DESCRIPTION
Hello, `shallowCopy` has been removed for ARC/ORC since it does a deep copy with ARC/ORC → https://github.com/nim-lang/Nim/pull/20070

I don't know a good alternative for `shallowCopy`.

ref https://github.com/nim-lang/Nim/pull/19972